### PR TITLE
Add support for extensible custom handlers

### DIFF
--- a/examples/extensible-custom-handler/yapp.yml
+++ b/examples/extensible-custom-handler/yapp.yml
@@ -1,0 +1,11 @@
+---
+routes:
+  GET /handlethis:
+    handler: | # Note that every custom handler must match this signature EXACTLY
+      import "net/http"
+
+      func serveHTTP(res http.ResponseWriter, req *http.Request) {
+        res.WriteHeader(http.StatusOK)
+
+        res.Write([]byte("this is a bad idea, ok!"))
+      }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/k14s/ytt v0.37.0
 	github.com/spf13/cobra v1.2.1
+	github.com/traefik/yaegi v0.10.0
 	gopkg.in/yaml.v2 v2.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -240,6 +240,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
+github.com/traefik/yaegi v0.10.0 h1:c/0rhUcj5+KJhJX++eCrPeKXnJaOZ17X8gYCznU9Xxc=
+github.com/traefik/yaegi v0.10.0/go.mod h1:RuCwD8/wsX7b6KoQHOaIFUfuH3gQIK4KWnFFmJMw5VA=
 github.com/urfave/cli/v2 v2.2.0/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
 github.com/vito/go-interact v0.0.0-20171111012221-fa338ed9e9ec/go.mod h1:wPlfmglZmRWMYv/qJy3P+fK/UnoQB5ISk4txfNd9tDo=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,7 @@ type RouteConfig struct {
 	Status  *int
 	Headers map[string][]string
 	Body    interface{}
+	Handler string
 }
 
 type HandledRoute struct {


### PR DESCRIPTION
For when you need to put some `go` in your `yaml` in your `go`.

POSSIBLE FUTURE IMPROVEMENTS:
- Can we use `ytt` to template the `go` handler?